### PR TITLE
Added default line when selecting trips without measurements selected

### DIFF
--- a/LiRA-Map-ml/client/src/Components/RoadMeasurements/RideCards.tsx
+++ b/LiRA-Map-ml/client/src/Components/RoadMeasurements/RideCards.tsx
@@ -4,8 +4,9 @@ import { RiDeleteBack2Line } from 'react-icons/ri'
 
 import Checkbox from '../Checkbox';
 import SpinLoader from "../../assets/SpinLoader";
+import { parsePositionDisplay } from '../../assets/DataParsers';
 
-import { RideMeta, TripsOptions } from '../../models/models'
+import { RideMeta, TripsOptions, PositionDisplay } from '../../models/models'
 
 import '../../css/ridecard.css'
 import '../../css/spinner.css'
@@ -23,11 +24,13 @@ const Cards: FC<CardsProps> = ( { showMetas, onClick } ) => {
     const renderRow: ListRowRenderer = ( { index, key, style } ): ReactNode => {
         const meta = showMetas[index];
 
+        const positionDisplays = parsePositionDisplay(meta.StartPositionDisplay, meta.EndPositionDisplay);
+
         return <div key={key} style={style}>
             <Checkbox 
                 forceState={meta.selected}
                 className="ride-card-container"
-                html={<div><b>{meta.wayPointName}</b><br></br>{new Date(meta.Created_Date).toLocaleDateString()}</div>}
+                html={<div><b>{positionDisplays.StartPosition + " -> " + positionDisplays.EndPosition}</b><br></br>{new Date(meta.Created_Date).toLocaleDateString()}</div>}
                 onClick={(isChecked) => {
                     onClick(meta, index, isChecked) 
                 }} />

--- a/LiRA-Map-ml/client/src/Components/RoadMeasurements/Rides.tsx
+++ b/LiRA-Map-ml/client/src/Components/RoadMeasurements/Rides.tsx
@@ -16,6 +16,7 @@ import RidesMap from "./RidesMap";
 import usePopup from "../createPopup";
 import { Popup } from "Leaflet.MultiOptionsPolyline";
 import { PopupFunc } from "../../models/popup"
+import { RendererName } from "../../models/renderers";
 
 const Rides: FC = () => {
     
@@ -30,6 +31,18 @@ const Rides: FC = () => {
 
         const updatePaths = async ( pop: PopupFunc) => {
             const temp = {} as MeasMetaPath;
+
+            if(selectedMeasurements.length == 0){
+                const activeBaselineMeasurement: ActiveMeasProperties = {
+                    dbName: "track.pos",
+                    name: "baseline reading without measurements",
+                    hasValue: false,
+                    rendererName: RendererName.line,
+                    color: 'black',
+                    isActive: true,
+                };
+                selectedMeasurements.push(activeBaselineMeasurement);
+            }
 
             for ( let meas of selectedMeasurements )
             {

--- a/LiRA-Map-ml/client/src/assets/DataParsers.ts
+++ b/LiRA-Map-ml/client/src/assets/DataParsers.ts
@@ -1,6 +1,7 @@
 import {RendererName} from "../models/renderers";
 import { JSONProps, PointData } from "../models/path";
 import { PathProperties } from "../models/properties";
+import { PositionDisplay } from "../models/models";
 
 export const parseSegments = (data: any): JSONProps[] => {
     // EXAMPLE OF ROW
@@ -31,4 +32,27 @@ export const parseSegments = (data: any): JSONProps[] => {
     } )
 }
 
+export function parsePositionDisplay(startPosition: string, endPosition: string): PositionDisplay {
+    let parsedStart = JSON.parse(startPosition);
+    let parsedEnd = JSON.parse(endPosition);
 
+    const positionDisplay: PositionDisplay = {
+        StartPosition: scopePositionOut(parsedStart),
+        EndPosition: scopePositionOut(parsedEnd),
+    }
+
+    return positionDisplay;
+};
+
+function scopePositionOut(position:any) {
+    if (position.road == null) {
+        if(position.city == null) {
+            if(position.county == null) {
+                return "Ukendt";
+            }
+            return position.county;
+        }
+        return position.city;
+    }
+    return position.road;
+}

--- a/LiRA-Map-ml/client/src/models/models.ts
+++ b/LiRA-Map-ml/client/src/models/models.ts
@@ -18,6 +18,11 @@ export interface RideMeta {
 	wayPointName: string,
 }
 
+export interface PositionDisplay {
+	StartPosition: string,
+	EndPosition: string,
+}
+
 // export interface MeasurementData {
 // 	T: string,
 // 	lat: number,

--- a/LiRA-Map-ml/server-nest/src/database.ts
+++ b/LiRA-Map-ml/server-nest/src/database.ts
@@ -37,11 +37,11 @@ const BASE_CONFIG = {
 export const LIRA_DB_CONFIG = {
     ...BASE_CONFIG,
     connection: {
-        host : LIRA_DB_SERVER,
+        host : "liradb.compute.dtu.dk", // "liradbdev.compute.dtu.dk",
         port: 5435,
-        user : LIRA_DB_USER,
-        password : LIRA_DB_PASSWORD,
-        database : LIRA_DB_DATABASE
+        user : "guest",
+        password : "V2GjxQVn",
+        database : "postgres"
     },
 }
 


### PR DESCRIPTION
Updated how roadnames are displayed in measurements, now tries to fetch road name, city and county, in that order

Changes developed by @cbfallesen and @Andreasbirch 